### PR TITLE
持ち時間の実装

### DIFF
--- a/components/modal/index.html
+++ b/components/modal/index.html
@@ -1,9 +1,23 @@
 <div v-if="showModal">
-  <div class="container" @click.self="close">
+  <div v-if="notClickSelf" class="container">
     <div :class="{ modal: true, close: isClose }">
       <div class="modal-content">
-        <slot name="content" />
-        <div :class="{ 'modal-btns': true, wrap: isWrap, nowrap: !isWrap }">
+        <div>
+          <slot name="content" />
+        </div>
+        <div v-if="$slots.btns" :class="{ 'modal-btns': true, wrap: isWrap, nowrap: !isWrap }">
+          <slot name="btns" />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div v-else class="container" @click.self="close">
+    <div :class="{ modal: true, close: isClose }">
+      <div class="modal-content">
+        <div>
+          <slot name="content" />
+        </div>
+        <div v-if="$slots.btns" :class="{ 'modal-btns': true, wrap: isWrap, nowrap: !isWrap }">
           <slot name="btns" />
         </div>
       </div>

--- a/components/modal/index.js
+++ b/components/modal/index.js
@@ -8,6 +8,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    notClickSelf: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {

--- a/components/modal/index.scss
+++ b/components/modal/index.scss
@@ -23,10 +23,19 @@
 
   &-content {
     width: 100%;
+
+    & > div:first-of-type {
+      margin: 0 0 100px;
+    }
+
+    & > div:last-of-type {
+      margin: 0;
+    }
+
     & p {
       text-align: center;
       font-size: 3.6rem;
-      margin: 0 0 100px;
+      margin: 0;
     }
   }
 

--- a/pages/gohome/index.html
+++ b/pages/gohome/index.html
@@ -122,7 +122,7 @@
       </Button>
     </template>
   </Modal>
-  <Modal ref="forceSelectWordModal">
+  <Modal ref="forceSelectWordModal" :not-click-self="true">
     <template v-slot:content>
       <p>持ち時間が過ぎたため 『{{ selectedWord.word }}』を選択しました</p>
     </template>

--- a/pages/gohome/index.html
+++ b/pages/gohome/index.html
@@ -14,12 +14,13 @@
           [{{ pekora.baseWord ? pekora.baseWord.word : '' }}]
         </p>
       </div>
-      <p
-        class="turn-count"
-        :class="{'danger': countdown <= 5}"
-      >
-        {{ countdown }}
-      </p>
+      <div class="turn-info">
+        <p class="turn-count">ターン数:&nbsp;{{turn.count}}</p>
+        <p class="turn-countdown">
+          のこり:&nbsp;
+          <span :class="{'danger': countdown <= 5}">{{ countdown }}</span>
+        </p>
+      </div>
       <div
         class="turn-which"
         :class="{

--- a/pages/gohome/index.html
+++ b/pages/gohome/index.html
@@ -14,7 +14,12 @@
           [{{ pekora.baseWord ? pekora.baseWord.word : '' }}]
         </p>
       </div>
-      <p class="turn-count">{{ this.countdown }}</p>
+      <p
+        class="turn-count"
+        :class="{'danger': countdown <= 5}"
+      >
+        {{ countdown }}
+      </p>
       <div
         class="turn-which"
         :class="{

--- a/pages/gohome/index.html
+++ b/pages/gohome/index.html
@@ -14,7 +14,7 @@
           [{{ pekora.baseWord ? pekora.baseWord.word : '' }}]
         </p>
       </div>
-      <p class="turn-count">{{ turn.count }}</p>
+      <p class="turn-count">{{ this.countdown }}</p>
       <div
         class="turn-which"
         :class="{
@@ -61,7 +61,7 @@
             <span>よくない</span>
           </template>
         </Button>
-        <Button text="よい" @click.native="turnProcess(selectedWord)">
+        <Button @click.native="turnProcess(selectedWord)">
           <template v-slot:text>
             <span>よい</span>
           </template>
@@ -120,6 +120,11 @@
           <span>おつかれ</span>
         </template>
       </Button>
+    </template>
+  </Modal>
+  <Modal ref="forceSelectWordModal">
+    <template v-slot:content>
+      <p>持ち時間が過ぎたため 『{{ selectedWord.word }}』を選択しました</p>
     </template>
   </Modal>
 </div>

--- a/pages/gohome/index.js
+++ b/pages/gohome/index.js
@@ -28,6 +28,8 @@ export default {
       selectedWord: '',
       winner: '',
       turn: new Turn(),
+      countdown: 30,
+      countdownTimerID: null,
     }
   },
   mounted() {
@@ -38,6 +40,7 @@ export default {
       this.getFirstWord()
       this.getWords()
       this.showTurnAnimation()
+      this.startTimer()
     },
     getFirstWord() {
       this.pekora.baseWord = this.$getFirstWord()
@@ -87,6 +90,7 @@ export default {
       this.setActiveTurn()
       this.getWords()
       this.showTurnAnimation()
+      this.startTimer()
     },
     movePlayer(word) {
       if (this.isPekoraTurn())
@@ -102,6 +106,32 @@ export default {
     },
     isPekoraTurn() {
       return this.turn.count % 2 !== 0
+    },
+    startTimer() {
+      clearTimeout(this.countdownTimerID)
+      this.countdown = 30
+      setTimeout(() => {
+        this.countdownTimer()
+      }, 2500)
+    },
+    countdownTimer() {
+      if (this.countdown > 0) {
+        this.countdownTimerID = setTimeout(() => {
+          this.countdown -= 1
+          this.countdownTimer()
+        }, 1000)
+      } else {
+        this.forceSelectWord()
+      }
+    },
+    forceSelectWord() {
+      const randomIndex = Math.floor(Math.random() * this.words.length)
+      this.selectedWord = this.words[randomIndex]
+      this.$refs.forceSelectWordModal.open()
+      setTimeout(() => {
+        this.$refs.forceSelectWordModal.close()
+        this.turnProcess(this.selectedWord)
+      }, 3000)
     },
   },
 }

--- a/pages/gohome/index.scss
+++ b/pages/gohome/index.scss
@@ -15,9 +15,25 @@
     margin: 0 0 10px;
   }
 
+  &-info {
+    display: flex;
+    align-items: center;
+    font-size: 3.6rem;
+  }
+
   &-count {
-    font-size: 5rem;
-    margin: 0;
+    margin: 0 10px;
+  }
+
+  &-countdown {
+    display: flex;
+    align-items: center;
+    margin: 0 10px;
+
+    & > span {
+      min-width: 40px;
+      text-align: right;
+    }
   }
 
   &-which {
@@ -77,4 +93,5 @@
 
 .danger {
   color: #ff0000;
+  font-size: 4.8rem;
 }

--- a/pages/gohome/index.scss
+++ b/pages/gohome/index.scss
@@ -74,3 +74,7 @@
     margin: 0;
   }
 }
+
+.danger {
+  color: #ff0000;
+}


### PR DESCRIPTION
close #51 

- 持ち時間の実装(持ち時間30秒)
- ターン数を表示していた箇所に持ち時間を表示
- 持ち時間(30秒)が過ぎるとランダムで単語を選択し、`持ち時間が過ぎたため 『単語』を選択しました`の文言を付与しモーダルを3秒表示
- 上記のモーダルの実装に伴い、モーダルコンポーネントの修正(スタイルと`@click.self`の切り替え)