### PR TITLE
各画面にメニューコンポーネントの追加

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -1,7 +1,9 @@
 <div>
   <main>
-    <transition name="page">
-      <Nuxt />
+    <transition name="layout">
+      <transition name="page">
+        <Nuxt />
+      </transition>
     </transition>
   </main>
 </div>

--- a/layouts/default.scss
+++ b/layouts/default.scss
@@ -6,6 +6,14 @@
   }
 }
 
+.layout-enter {
+  opacity: 0;
+
+  &-active {
+    transition: opacity 1.5s;
+  }
+}
+
 html {
   font-size: 10px;
 }

--- a/layouts/menu/index.html
+++ b/layouts/menu/index.html
@@ -1,10 +1,12 @@
 <div>
   <main>
-    <transition name="page">
-      <div>
-        <Menu />
-        <Nuxt />
-      </div>
+    <transition name="layout">
+      <transition name="page">
+        <div>
+          <Menu />
+          <Nuxt />
+        </div>
+      </transition>
     </transition>
   </main>
 </div>

--- a/layouts/menu/index.scss
+++ b/layouts/menu/index.scss
@@ -6,6 +6,14 @@
   }
 }
 
+.layout-enter {
+  opacity: 0;
+
+  &-active {
+    transition: opacity 1.5s;
+  }
+}
+
 html {
   font-size: 10px;
 }

--- a/pages/character-select/index.js
+++ b/pages/character-select/index.js
@@ -4,6 +4,7 @@ export default {
   components: {
     Button,
   },
+  layout: 'menu/index',
   data() {
     return {
       isPekoraTab: true,

--- a/pages/join/index.js
+++ b/pages/join/index.js
@@ -4,6 +4,7 @@ export default {
   components: {
     Button,
   },
+  layout: 'menu/index',
   data() {
     return {
       logo: `${process.env.MITSU_URL}/images/logo/logo_white.svg`,

--- a/pages/join/private/index.js
+++ b/pages/join/private/index.js
@@ -6,6 +6,7 @@ export default {
     Button,
     TextBox,
   },
+  layout: 'menu/index',
   data() {
     return {
       worldId: '',

--- a/pages/join/public/index.js
+++ b/pages/join/public/index.js
@@ -4,6 +4,7 @@ export default {
   components: {
     Button,
   },
+  layout: 'menu/index',
   data() {
     return {
       worlds: [

--- a/pages/rank/index.js
+++ b/pages/rank/index.js
@@ -1,4 +1,5 @@
 export default {
+  layout: 'menu/index',
   data() {
     return {
       ranks: [

--- a/pages/ranking/index.js
+++ b/pages/ranking/index.js
@@ -1,4 +1,5 @@
 export default {
+  layout: 'menu/index',
   data() {
     return {
       rankings: [

--- a/pages/recruit/index.js
+++ b/pages/recruit/index.js
@@ -14,6 +14,7 @@ export default {
     TextBoxIcon,
     Tooltip,
   },
+  layout: 'menu/index',
   data() {
     return {
       worldId: '',

--- a/pages/rule/index.js
+++ b/pages/rule/index.js
@@ -4,6 +4,7 @@ export default {
   components: {
     Button,
   },
+  layout: 'menu/index',
   data() {
     return {
       rules: [],


### PR DESCRIPTION
以下実装しましたので確認お願いします。

- ログイン後の画面に`layout: 'menu/index'`を追加し、メニューコンポーネントを追加
- layout transitionを使用し、layoutが異なる画面へ遷移する際にもアニメーションをするように実装